### PR TITLE
updating Docker version per Docker Docs for Centos 7.4 and our DCOS Docs

### DIFF
--- a/platform/cloud/aws/centos_7.4/setup.sh
+++ b/platform/cloud/aws/centos_7.4/setup.sh
@@ -2,22 +2,11 @@
 
 sudo setenforce 0 && \
 sudo sed -i --follow-symlinks 's/^SELINUX=.*/SELINUX=disabled/g' /etc/sysconfig/selinux
-sudo tee /etc/yum.repos.d/docker.repo <<-'EOF'
-[dockerrepo]
-name=Docker Repository
-baseurl=https://yum.dockerproject.org/repo/main/centos/7
-enabled=1
-gpgcheck=1
-gpgkey=https://yum.dockerproject.org/gpg
-EOF
-# sudo yum -y update --exclude="docker-engine*"
-sudo mkdir -p /etc/systemd/system/docker.service.d
-sudo tee /etc/systemd/system/docker.service.d/override.conf <<- EOF
-[Service]
-ExecStart=
-ExecStart=/usr/bin/docker daemon --storage-driver=overlay
-EOF
-sudo yum install -y docker-engine-1.13.1
+sudo echo 'overlay' >> /etc/modules-load.d/overlay.conf
+sudo modprobe overlay
+sudo yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+sudo yum install -y yum-utils device-mapper-persistent-data lvm2
+sudo yum install docker-ce
 sudo systemctl start docker
 sudo systemctl enable docker
 sudo yum install -y wget


### PR DESCRIPTION
Removing the docker-engine for the use of the docker-ce package supported per our docs site for Centos/RHEL https://docs.mesosphere.com/1.11/installing/production/system-requirements/docker-centos/. Steps removed/added according to Docker install guide for Centos https://docs.docker.com/install/linux/docker-ce/centos/.