### PR TITLE
adding centos_7.5 with docker 1.13.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ module "dcos-tested-oses" {
 | aws_ami | AMI that will be used for the instances instead of Mesosphere provided AMIs | map | `<map>` | no |
 | aws_default_os_user | Map OS name to default login user (e.g. centos -> centos, coreos -> coreos) | map | `<map>` | no |
 | os | Operating system to use | string | `centos_7.4` | no |
-| provider | provider | string | `aws` | no |
+| provider | Provider to use | string | `aws` | no |
 | region | region | string | `` | no |
 
 ## Outputs
@@ -29,5 +29,5 @@ module "dcos-tested-oses" {
 |------|-------------|
 | aws_ami | AMI that will be used for the instances instead of Mesosphere provided AMIs |
 | os-setup | os-setup |
-| user | user |
+| user | User |
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,5 @@
 output "user" {
-  description = "user"
+  description = "User"
   value       = "${data.template_file.aws_ami_user.rendered}"
 }
 

--- a/platform/cloud/aws/centos_7.5/setup.sh
+++ b/platform/cloud/aws/centos_7.5/setup.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+sudo setenforce 0 && \
+sudo sed -i --follow-symlinks 's/^SELINUX=.*/SELINUX=disabled/g' /etc/sysconfig/selinux
+sudo tee /etc/yum.repos.d/docker.repo <<-'EOF'
+[dockerrepo]
+name=Docker Repository
+baseurl=https://yum.dockerproject.org/repo/main/centos/7
+enabled=1
+gpgcheck=1
+gpgkey=https://yum.dockerproject.org/gpg
+EOF
+
+sudo mkdir -p /etc/systemd/system/docker.service.d
+sudo tee /etc/systemd/system/docker.service.d/override.conf <<- EOF
+[Service]
+ExecStart=
+ExecStart=/usr/bin/dockerd
+EOF
+
+sudo yum install -y yum-utils \
+    device-mapper-persistent-data \
+    lvm2
+
+sudo yum-config-manager \
+    --add-repo \
+    https://download.docker.com/linux/centos/docker-ce.repo
+
+sudo yum makecache fast
+sudo yum install -y http://mirror.centos.org/centos/7/extras/x86_64/Packages/container-selinux-2.42-1.gitad8f0f7.el7.noarch.rpm
+sudo yum install -y http://mirror.centos.org/centos/7/extras/x86_64/Packages/pigz-2.3.3-1.el7.centos.x86_64.rpm
+
+#Installing RH's fork of docker 1.13.1
+sudo yum install -y docker
+sudo ln -s /usr/libexec/docker/docker-runc-current /usr/libexec/docker/docker-runc
+sudo ln -s ../../usr/libexec/docker/docker-proxy-current /usr/bin/docker-proxy
+
+sudo systemctl start docker
+sudo systemctl enable docker
+
+sudo yum install -y wget
+sudo yum install -y git
+sudo yum install -y unzip
+sudo yum install -y curl
+sudo yum install -y xz
+sudo yum install -y ipset
+sudo yum install -y bind-utils
+sudo yum install -y ntp
+sudo systemctl enable ntpd
+sudo systemctl start ntpd
+sudo getent group nogroup || sudo groupadd nogroup
+sudo getent group docker || sudo groupadd docker
+sudo touch /opt/dcos-prereqs.installed

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,5 @@
 variable "provider" {
-  description = "provider"
+  description = "Provider to use"
   default     = "aws"
 }
 
@@ -79,6 +79,23 @@ variable "aws_ami" {
     centos_7.4_us-east-2      = "ami-2d103948"
     centos_7.4_us-west-1      = "ami-b1a59fd1"
     centos_7.4_us-west-2      = "ami-02c71d7a"
+
+    # Centos 7.5
+    centos_7.5_ap-south-1     = "ami-1780a878"
+    centos_7.5_eu-west-3      = "ami-262e9f5b"
+    centos_7.5_eu-west-2      = "ami-00846a67"
+    centos_7.5_eu-west-1      = "ami-3548444c"
+    centos_7.5_ap-northeast-2 = "ami-bf9c36d1"
+    centos_7.5_ap-northeast-1 = "ami-8e8847f1"
+    centos_7.5_sa-east-1      = "ami-cb5803a7"
+    centos_7.5_ca-central-1   = "ami-e802818c"
+    centos_7.5_ap-southeast-1 = "ami-8e0205f2"
+    centos_7.5_ap-southeast-2 = "ami-d8c21dba"
+    centos_7.5_eu-central-1   = "ami-dd3c0f36"
+    centos_7.5_us-east-1      = "ami-9887c6e7"
+    centos_7.5_us-east-2      = "ami-9c0638f9"
+    centos_7.5_us-west-1      = "ami-4826c22b"
+    centos_7.5_us-west-2      = "ami-3ecc8f46"
 
     # CoreOS 835.13.0
     coreos_835.13.0_eu-west-1      = "ami-4b18aa38"


### PR DESCRIPTION
We need to update the CentOS version to 7.5 that is using the RHEL version of docker according to DC/OS specifications.

Docker 1.13.1 will be included in this version of CentOS 7.5.

See below:
https://docs.mesosphere.com/version-policy/

https://jira.mesosphere.com/browse/DCOS-44386