### PR TITLE
vars: updating the aws_ami description

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ module "dcos-tested-oses" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| aws_ami | AMI that will be used for the instances instead of Mesosphere provided AMIs | map | `<map>` | no |
+| aws_ami | AMI that will be used for the instances instead of the Mesosphere chosen default images. Custom AMIs must fulfill the Mesosphere DC/OS system-requirements: See https://docs.mesosphere.com/1.12/installing/production/system-requirements/ | map | `<map>` | no |
 | aws_default_os_user | Map OS name to default login user (e.g. centos -> centos, coreos -> coreos) | map | `<map>` | no |
 | os | Operating system to use | string | `centos_7.4` | no |
 | provider | Provider to use | string | `aws` | no |
@@ -27,7 +27,7 @@ module "dcos-tested-oses" {
 
 | Name | Description |
 |------|-------------|
-| aws_ami | AMI that will be used for the instances instead of Mesosphere provided AMIs |
+| aws_ami | AMI that will be used for the instances instead of the Mesosphere chosen default images. Custom AMIs must fulfill the Mesosphere DC/OS system-requirements: See https://docs.mesosphere.com/1.12/installing/production/system-requirements/ |
 | os-setup | os-setup |
 | user | User |
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,7 +4,7 @@ output "user" {
 }
 
 output "aws_ami" {
-  description = "AMI that will be used for the instances instead of Mesosphere provided AMIs"
+  description = "AMI that will be used for the instances instead of the Mesosphere chosen default images. Custom AMIs must fulfill the Mesosphere DC/OS system-requirements: See https://docs.mesosphere.com/1.12/installing/production/system-requirements/"
   value       = "${data.template_file.aws_ami.rendered}"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -27,7 +27,7 @@ variable "aws_default_os_user" {
 
 # AWS recommends all HVM vs PV. HVM Below.
 variable "aws_ami" {
-  description = "AMI that will be used for the instances instead of Mesosphere provided AMIs"
+  description = "AMI that will be used for the instances instead of the Mesosphere chosen default images. Custom AMIs must fulfill the Mesosphere DC/OS system-requirements: See https://docs.mesosphere.com/1.12/installing/production/system-requirements/"
   type        = "map"
 
   default = {


### PR DESCRIPTION
https://jira.mesosphere.com/browse/DCOS-47942

This commit is to be more descriptive on the aws_ami variable to allow users more visibility into what AMI's are required and how they are built.
The link to the mesosphere documentation is in the description of the variable.