### PR TITLE
centos: moving from ntp to chrony

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@ AWS Tested OSes
 ============
 This module returns for an given OS the AMI aswell as its default user and the prerequisits script
 
-
 EXAMPLE
 -------
 ```hcl
@@ -12,22 +11,21 @@ module "dcos-tested-oses" {
 }
 ```
 
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| aws_ami | AMI that will be used for the instances instead of the Mesosphere chosen default images. Custom AMIs must fulfill the Mesosphere DC/OS system-requirements: See https://docs.mesosphere.com/1.12/installing/production/system-requirements/ | map | `<map>` | no |
-| aws_default_os_user | Map OS name to default login user (e.g. centos -> centos, coreos -> coreos) | map | `<map>` | no |
-| os | Operating system to use | string | `centos_7.4` | no |
-| provider | Provider to use | string | `aws` | no |
-| region | region | string | `` | no |
+| aws\_ami | AMI that will be used for the instances instead of the Mesosphere chosen default images. Custom AMIs must fulfill the Mesosphere DC/OS system-requirements: See https://docs.mesosphere.com/1.12/installing/production/system-requirements/ | map | `<map>` | no |
+| aws\_default\_os\_user | Map OS name to default login user (e.g. centos -> centos, coreos -> coreos) | map | `<map>` | no |
+| os | Operating system to use | string | `"centos_7.4"` | no |
+| provider | Provider to use | string | `"aws"` | no |
+| region | region | string | `""` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| aws_ami | AMI that will be used for the instances instead of the Mesosphere chosen default images. Custom AMIs must fulfill the Mesosphere DC/OS system-requirements: See https://docs.mesosphere.com/1.12/installing/production/system-requirements/ |
+| aws\_ami | AMI that will be used for the instances instead of the Mesosphere chosen default images. Custom AMIs must fulfill the Mesosphere DC/OS system-requirements: See https://docs.mesosphere.com/1.12/installing/production/system-requirements/ |
 | os-setup | os-setup |
 | user | User |
 

--- a/platform/cloud/aws/centos_7.2/setup.sh
+++ b/platform/cloud/aws/centos_7.2/setup.sh
@@ -30,8 +30,8 @@ sudo yum install -y unzip
 sudo yum install -y curl
 sudo yum install -y xz
 sudo yum install -y ipset
-sudo yum install -y ntp
-sudo systemctl enable ntpd
-sudo systemctl start ntpd
+sudo yum install -y chrony
+sudo systemctl enable chronyd
+sudo systemctl start chronyd
 sudo getent group nogroup || sudo groupadd nogroup
 sudo touch /opt/dcos-prereqs.installed

--- a/platform/cloud/aws/centos_7.3/setup.sh
+++ b/platform/cloud/aws/centos_7.3/setup.sh
@@ -25,9 +25,9 @@ sudo yum install -y unzip
 sudo yum install -y curl
 sudo yum install -y xz
 sudo yum install -y ipset
-sudo yum install -y ntp
-sudo systemctl enable ntpd
-sudo systemctl start ntpd
+sudo yum install -y chrony
+sudo systemctl enable chronyd
+sudo systemctl start chronyd
 sudo getent group nogroup || sudo groupadd nogroup
 sudo getent group docker || sudo groupadd docker
 sudo touch /opt/dcos-prereqs.installed

--- a/platform/cloud/aws/centos_7.4/setup.sh
+++ b/platform/cloud/aws/centos_7.4/setup.sh
@@ -15,9 +15,9 @@ sudo yum install -y unzip
 sudo yum install -y curl
 sudo yum install -y xz
 sudo yum install -y ipset
-sudo yum install -y ntp
-sudo systemctl enable ntpd
-sudo systemctl start ntpd
+sudo yum install -y chrony
+sudo systemctl enable chronyd
+sudo systemctl start chronyd
 sudo getent group nogroup || sudo groupadd nogroup
 sudo getent group docker || sudo groupadd docker
 sudo touch /opt/dcos-prereqs.installed

--- a/platform/cloud/aws/centos_7.5/setup.sh
+++ b/platform/cloud/aws/centos_7.5/setup.sh
@@ -45,9 +45,9 @@ sudo yum install -y curl
 sudo yum install -y xz
 sudo yum install -y ipset
 sudo yum install -y bind-utils
-sudo yum install -y ntp
-sudo systemctl enable ntpd
-sudo systemctl start ntpd
+sudo yum install -y chrony
+sudo systemctl enable chronyd
+sudo systemctl start chronyd
 sudo getent group nogroup || sudo groupadd nogroup
 sudo getent group docker || sudo groupadd docker
 sudo touch /opt/dcos-prereqs.installed

--- a/platform/cloud/aws/rhel_7.3/setup.sh
+++ b/platform/cloud/aws/rhel_7.3/setup.sh
@@ -26,9 +26,9 @@ sudo yum install -y unzip
 sudo yum install -y curl
 sudo yum install -y xz
 sudo yum install -y ipset
-sudo yum install -y ntp
-sudo systemctl enable ntpd
-sudo systemctl start ntpd
+sudo yum install -y chrony
+sudo systemctl enable chronyd
+sudo systemctl start chronyd
 sudo getent group nogroup || sudo groupadd nogroup
 sudo getent group docker || sudo groupadd docker
 sudo touch /opt/dcos-prereqs.installed


### PR DESCRIPTION
This PR is related to improve time syncs for the unviersal installer

Related to these efforts below:
	https://github.com/dcos/dcos-launch/pull/206/files
	https://jira.mesosphere.com/browse/DCOS-46159